### PR TITLE
Fix search feature not working in all pages

### DIFF
--- a/src/forum/views.py
+++ b/src/forum/views.py
@@ -178,9 +178,9 @@ def visit_topics(request, topic_id):
 
 def search_page(request):
 
-    if request.method == 'POST':
+    if request.method == 'GET':
 
-        search_query = request.POST.get('search_word')
+        search_query = request.GET.get('search_word')
 
         if not search_query or search_query.strip() == "":
             return redirect(request.META.get('HTTP_REFERER', '/'))


### PR DESCRIPTION
### Summary
The search feature was failing because the Django view only accepted POST requests, 
while the frontend was sending GET requests.

### Changes
- Updated search view to use GET instead of POST

Closes #71