### PR TITLE
Configure local memory cache for password reset codes

### DIFF
--- a/src/main/settings.py
+++ b/src/main/settings.py
@@ -43,6 +43,13 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "unique-reset-cache",
+    }
+}
+
 ROOT_URLCONF = 'main.urls'
 
 TEMPLATES = [


### PR DESCRIPTION
## Changes Made
- Added `CACHES` configuration in `settings.py` using LocMemCache.
- This will store password reset codes temporarily (expires after 5 minutes).

Ref #105